### PR TITLE
Changes to allow libunwind to be linked to Rust x86_64-fortanix-unknown-sgx target

### DIFF
--- a/libunwind/CMakeLists.txt
+++ b/libunwind/CMakeLists.txt
@@ -272,7 +272,7 @@ if (LIBUNWIND_ENABLE_ASSERTIONS)
 
   # On Release builds cmake automatically defines NDEBUG, so we
   # explicitly undefine it:
-  if (uppercase_CMAKE_BUILD_TYPE STREQUAL "RELEASE")
+  if ((uppercase_CMAKE_BUILD_TYPE STREQUAL "RELEASE") AND (NOT RUST_SGX))
     list(APPEND LIBUNWIND_COMPILE_FLAGS -UNDEBUG)
   endif()
 else()

--- a/libunwind/README_RUST_SGX.md
+++ b/libunwind/README_RUST_SGX.md
@@ -1,0 +1,22 @@
+# Libunwind customizations for linking with x86_64-fortanix-unknown-sgx Rust target.
+
+## Description
+### Initial Fork
+Initial Fork has been made from 5.0 release of llvm (commit: 6a075b6de4)
+### Detailed Description
+#### Header files that we do not include for this target
+1. pthread.h
+#### Library that we do not link to for this target.
+1. pthread (Locks used by libunwind is provided by rust stdlib for this target)
+
+## Building unwind for rust-sgx target
+### Generate Make files:
+* `cd where you want to build libunwind`
+* `mkdir build`
+* `cd build`
+* `cmake -DCMAKE_BUILD_TYPE="RELEASE" -DRUST_SGX=1 -G "Unix Makefiles" -DLLVM_PATH=<path/to/llvm> <path/to/libunwind>`
+* `-DCMAKE_BUILD_TYPE="RELEASE"` could be removed to enable debug logs of libunwind.
+
+### Build:
+* `make unwind_static`
+* `build/lib/` will have the built library.

--- a/libunwind/docs/BuildingLibunwind.rst
+++ b/libunwind/docs/BuildingLibunwind.rst
@@ -165,3 +165,8 @@ libunwind specific options
 .. option:: LIBUNWIND_SYSROOT
 
   Sysroot for cross compiling
+
+.. option:: LIBUNWIND_ENABLE_RUST_SGX:BOOL
+
+  **Default**: ``OFF``
+

--- a/libunwind/src/CMakeLists.txt
+++ b/libunwind/src/CMakeLists.txt
@@ -9,16 +9,10 @@ set(LIBUNWIND_C_SOURCES
     UnwindLevel1.c
     UnwindLevel1-gcc-ext.c
     Unwind-sjlj.c)
-set_source_files_properties(${LIBUNWIND_C_SOURCES}
-                            PROPERTIES
-                              COMPILE_FLAGS "-std=c99")
 
 set(LIBUNWIND_ASM_SOURCES
     UnwindRegistersRestore.S
     UnwindRegistersSave.S)
-set_source_files_properties(${LIBUNWIND_ASM_SOURCES}
-                            PROPERTIES
-                              LANGUAGE C)
 
 set(LIBUNWIND_HEADERS
     AddressSpace.hpp
@@ -32,6 +26,7 @@ set(LIBUNWIND_HEADERS
     Registers.hpp
     UnwindCursor.hpp
     unwind_ext.h
+    UnwindRustSgx.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/libunwind.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/unwind.h)
 
@@ -44,6 +39,31 @@ if (MSVC_IDE)
   source_group("Header Files" FILES ${LIBUNWIND_HEADERS})
 endif()
 
+if (RUST_SGX)
+    # Compile Flags
+    add_definitions(-DRUST_SGX)
+    add_definitions(-DU_FORTIFY_SOURCE)
+    add_definitions(-D_FORTIFY_SOURCE=0)
+    add_definitions(-D__NO_STRING_INLINES)
+    add_definitions(-D__NO_MATH_INLINES)
+    add_definitions(-D_LIBUNWIND_IS_BAREMETAL)
+    list(APPEND LIBUNWIND_COMPILE_FLAGS -fno-stack-protector)
+    list(APPEND LIBUNWIND_COMPILE_FLAGS -ffreestanding)
+    list(APPEND LIBUNWIND_COMPILE_FLAGS -fexceptions)
+
+    # Sources
+    list(APPEND LIBUNWIND_C_SOURCES UnwindRustSgx.c)
+    list(APPEND LIBUNWIND_C_SOURCES UnwindRustSgxSnprintf.c)
+endif()
+
+
+set_source_files_properties(${LIBUNWIND_C_SOURCES}
+                            PROPERTIES
+                              COMPILE_FLAGS "-std=c99")
+set_source_files_properties(${LIBUNWIND_ASM_SOURCES}
+                            PROPERTIES
+                              LANGUAGE C)
+
 set(LIBUNWIND_SOURCES
     ${LIBUNWIND_CXX_SOURCES}
     ${LIBUNWIND_C_SOURCES}
@@ -53,7 +73,7 @@ set(LIBUNWIND_SOURCES
 set(libraries ${LIBUNWINDCXX_ABI_LIBRARIES})
 append_if(libraries LIBUNWIND_HAS_C_LIB c)
 append_if(libraries LIBUNWIND_HAS_DL_LIB dl)
-if (LIBUNWIND_ENABLE_THREADS)
+if (LIBUNWIND_ENABLE_THREADS AND (NOT RUST_SGX))
   append_if(libraries LIBUNWIND_HAS_PTHREAD_LIB pthread)
 endif()
 

--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -16,7 +16,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#ifndef _LIBUNWIND_HAS_NO_THREADS
+#if !defined(_LIBUNWIND_HAS_NO_THREADS) && !defined(RUST_SGX)
   #include <pthread.h>
 #endif
 #include <unwind.h>

--- a/libunwind/src/UnwindRustSgx.c
+++ b/libunwind/src/UnwindRustSgx.c
@@ -1,0 +1,173 @@
+//===--------------------- UnwindRustSgx.c ----------------------------------===//
+//
+////                     The LLVM Compiler Infrastructure
+////
+//// This file is dual licensed under the MIT and the University of Illinois Open
+//// Source Licenses. See LICENSE.TXT for details.
+////
+////
+////===----------------------------------------------------------------------===//
+
+#define _GNU_SOURCE
+#include <link.h>
+
+#include <elf.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stddef.h>
+#include "UnwindRustSgx.h"
+
+
+#define max_log 256
+
+
+__attribute__((weak)) struct _IO_FILE *stderr  = -1;
+
+static int vwrite_err(const char *format, va_list ap)
+{
+    char s[max_log];
+    int len = 0;
+    s[0]='\0';
+    len = vsnprintf(s, max_log, format, ap);
+    __rust_print_err((uint8_t *)s, len);
+    return len;
+}
+
+static int write_err(const char *format, ...)
+{
+    int ret;
+    va_list args;
+        va_start(args, format);
+    ret = vwrite_err(format, args);
+    va_end(args);
+
+
+    return ret;
+}
+
+__attribute__((weak)) int fprintf (FILE *__restrict __stream,
+            const char *__restrict __format, ...)
+{
+
+    int ret;
+    if (__stream != stderr) {
+        write_err("Rust SGX Unwind supports only writing to stderr\n");
+        return -1;
+    } else {
+        va_list args;
+        int ret = 0;
+        va_start(args, __format);
+        ret += vwrite_err(__format, args);
+        va_end(args);
+    }
+
+    return ret;
+}
+
+__attribute__((weak)) int fflush (FILE *__stream)
+{
+    // We do not need to do anything here.
+    return 0;
+}
+
+
+
+
+__attribute__((weak)) void __assert_fail(const char * assertion,
+                                       const char * file,
+                           unsigned int line,
+                           const char * function)
+{
+    write_err("%s:%d %s %s\n", file, line, function, assertion);
+    abort();
+}
+
+
+
+// We do not report stack over flow detected.
+// Calling write_err uses more stack due to the way we have implemented it.
+// With possible enabling of stack probes, we should not
+// get into __stack_chk_fail() at all.
+__attribute__((weak))  void __stack_chk_fail() {
+    abort();
+}
+
+/*
+ * Below are defined for all executibles compiled for
+ * x86_64-fortanix-unknown-sgx rust target.
+ * Ref: rust/src/libstd/sys/sgx/abi/entry.S
+ */
+
+extern uint64_t TEXT_BASE;
+extern uint64_t TEXT_SIZE;
+extern uint64_t EH_FRM_HDR_BASE;
+extern uint64_t EH_FRM_HDR_SIZE;
+extern void IMAGE_BASE;
+
+typedef Elf64_Phdr Elf_Phdr; 
+int
+dl_iterate_phdr (int (*callback) (struct dl_phdr_info *,
+                  size_t, void *),
+         void *data)
+{
+    struct dl_phdr_info info;
+    struct dl_phdr_info *pinfo = &info;
+    Elf_Phdr phdr[2];
+    int ret = 0;
+
+
+    size_t text_size = TEXT_SIZE;
+    size_t eh_base_size = EH_FRM_HDR_SIZE;
+
+    memset(pinfo, 0, sizeof(*pinfo));
+
+    pinfo->dlpi_addr = &IMAGE_BASE;
+    pinfo->dlpi_phnum = 2;
+
+    pinfo->dlpi_phdr = phdr;
+    memset(phdr, 0, 2*sizeof(*phdr));
+
+
+    phdr[0].p_type = PT_LOAD;
+    phdr[0].p_vaddr = (size_t)TEXT_BASE;
+    phdr[0].p_memsz = text_size;
+
+    phdr[1].p_type = PT_GNU_EH_FRAME;
+    phdr[1].p_vaddr = (size_t)EH_FRM_HDR_BASE;
+    phdr[1].p_memsz = eh_base_size;
+
+
+    ret = callback (&info, sizeof (struct dl_phdr_info), data);
+    return ret;
+}
+
+struct libwu_rs_alloc_meta {
+    size_t alloc_size;
+    // Should we put a signatre guard before ptr for oob access?
+    unsigned char ptr[0];
+};
+
+#define META_FROM_PTR(__PTR) (struct libwu_rs_alloc_meta *) \
+    ((unsigned char *)__PTR - offsetof(struct libwu_rs_alloc_meta, ptr))
+
+void *libuw_malloc(size_t size)
+{
+    struct libwu_rs_alloc_meta *meta;
+    size_t alloc_size = size + sizeof(struct libwu_rs_alloc_meta);
+    meta = (void *)__rust_alloc(alloc_size, sizeof(size_t));
+    if (!meta) {
+        return NULL;
+    }
+    meta->alloc_size = alloc_size;
+    return (void *)meta->ptr;
+}
+
+void libuw_free(void *p)
+{
+    struct libwu_rs_alloc_meta *meta;
+    if (!p) {
+        return;
+    }
+    meta = META_FROM_PTR(p);
+    __rust_dealloc((unsigned char *)meta, meta->alloc_size, sizeof(size_t));
+}

--- a/libunwind/src/UnwindRustSgx.h
+++ b/libunwind/src/UnwindRustSgx.h
@@ -1,0 +1,108 @@
+//===--------------------- UnwindRustSgx.h ----------------------------------===//
+//
+////                     The LLVM Compiler Infrastructure
+////
+//// This file is dual licensed under the MIT and the University of Illinois Open
+//// Source Licenses. See LICENSE.TXT for details.
+////
+////
+////===----------------------------------------------------------------------===//
+
+#if !defined(UNWIND_RUST_SGX_H)
+#define UNWIND_RUST_SGX_H
+
+#ifdef RUST_SGX
+
+#define _GNU_SOURCE
+#include <link.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdint.h>
+
+// We have to use RWLock from rust repo, it is defined in:
+// src/libstd/sys/sgx/rwlock.rs.
+// rwlock.rs has compile time check to ensure sizeof(RWLock) = 128.
+typedef struct {
+    unsigned char opaque[128];
+} RWLock;
+
+// The below is obtained by printing initialized bytes
+// for RWLock in rust repo: src/libstd/sys/sgx/rwlock.rs.
+#define RWLOCK_INIT { \
+    0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, \
+}
+
+// These are the functions exposed by SGX-Rust.
+// The rust changes are available at:
+#ifdef __cplusplus
+extern "C"  {
+#endif
+    int __rust_rwlock_rdlock(RWLock *rwlock);
+    int __rust_rwlock_wrlock(RWLock *rwlock);
+    int __rust_rwlock_unlock(RWLock *rwlock);
+    unsigned char *__rust_alloc(size_t, size_t);
+    void __rust_dealloc(unsigned char *, size_t, size_t);
+    void __rust_print_err(uint8_t *m, int s);
+    __attribute__((noreturn)) void __rust_abort(void);
+    unsigned char *__rust_encl_address(size_t);
+#ifdef __cplusplus
+}
+#endif
+
+#define abort __rust_abort
+
+#undef pthread_rwlock_t
+#undef pthread_rwlock_rdlock
+#undef pthread_rwlock_wrlock
+#undef pthread_rwlock_unlock
+
+#define pthread_rwlock_t RWLock
+#define PTHREAD_RWLOCK_INITIALIZER RWLOCK_INIT
+
+
+#define pthread_rwlock_rdlock __rust_rwlock_rdlock
+#define pthread_rwlock_wrlock __rust_rwlock_wrlock
+#define pthread_rwlock_unlock __rust_rwlock_unlock
+
+
+#define malloc libuw_malloc
+#define free libuw_free
+
+#ifdef dl_iterate_phdr
+#undef dl_iterate_phdr
+#endif
+#define dl_iterate_phdr libuw_dl_iterate_phdr
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void *libuw_malloc(size_t size);
+
+void libuw_free(void *p);
+
+int
+libuw_dl_iterate_phdr (int (*callback) (struct dl_phdr_info *,
+                  size_t, void *), void *data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+#endif

--- a/libunwind/src/UnwindRustSgxSnprintf.c
+++ b/libunwind/src/UnwindRustSgxSnprintf.c
@@ -1,0 +1,853 @@
+/*
+ * Copyright Patrick Powell 1995
+ * This code is based on code written by Patrick Powell (papowell@astart.com)
+ * It may be used for any purpose as long as this notice remains intact
+ * on all source code distributions
+ */
+
+/**************************************************************
+ * Original:
+ * Patrick Powell Tue Apr 11 09:48:21 PDT 1995
+ * A bombproof version of doprnt (dopr) included.
+ * Sigh.  This sort of thing is always nasty do deal with.  Note that
+ * the version here does not include floating point...
+ *
+ * snprintf() is used instead of sprintf() as it does limit checks
+ * for string length.  This covers a nasty loophole.
+ *
+ * The other functions are there to prevent NULL pointers from
+ * causing nast effects.
+ *
+ * More Recently:
+ *  Brandon Long <blong@fiction.net> 9/15/96 for mutt 0.43
+ *  This was ugly.  It is still ugly.  I opted out of floating point
+ *  numbers, but the formatter understands just about everything
+ *  from the normal C string format, at least as far as I can tell from
+ *  the Solaris 2.5 printf(3S) man page.
+ *
+ *  Brandon Long <blong@fiction.net> 10/22/97 for mutt 0.87.1
+ *    Ok, added some minimal floating point support, which means this
+ *    probably requires libm on most operating systems.  Don't yet
+ *    support the exponent (e,E) and sigfig (g,G).  Also, fmtint()
+ *    was pretty badly broken, it just wasn't being exercised in ways
+ *    which showed it, so that's been fixed.  Also, formated the code
+ *    to mutt conventions, and removed dead code left over from the
+ *    original.  Also, there is now a builtin-test, just compile with:
+ *           gcc -DTEST_SNPRINTF -o snprintf snprintf.c -lm
+ *    and run snprintf for results.
+ * 
+ *  Thomas Roessler <roessler@guug.de> 01/27/98 for mutt 0.89i
+ *    The PGP code was using unsigned hexadecimal formats. 
+ *    Unfortunately, unsigned formats simply didn't work.
+ *
+ *  Michael Elkins <me@cs.hmc.edu> 03/05/98 for mutt 0.90.8
+ *    The original code assumed that both snprintf() and vsnprintf() were
+ *    missing.  Some systems only have snprintf() but not vsnprintf(), so
+ *    the code is now broken down under HAVE_SNPRINTF and HAVE_VSNPRINTF.
+ *
+ *  Andrew Tridgell (tridge@samba.org) Oct 1998
+ *    fixed handling of %.0f
+ *    added test for HAVE_LONG_DOUBLE
+ *
+ *  Russ Allbery <rra@stanford.edu> 2000-08-26
+ *    fixed return value to comply with C99
+ *    fixed handling of snprintf(NULL, ...)
+ *
+ **************************************************************/
+
+#include <string.h>
+#include <sys/types.h>
+
+/* Define this as a fall through, HAVE_STDARG_H is probably already set */
+
+#define HAVE_STDARG_H
+
+/* varargs declarations: */
+
+#if defined(HAVE_STDARG_H)
+# include <stdarg.h>
+# define HAVE_STDARGS    /* let's hope that works everywhere (mj) */
+# define VA_LOCAL_DECL   va_list ap
+# define VA_START(f)     va_start(ap, f)
+# define VA_SHIFT(v,t)  ;   /* no-op for ANSI */
+# define VA_END          va_end(ap)
+#else
+# if defined(HAVE_VARARGS_H)
+#  include <varargs.h>
+#  undef HAVE_STDARGS
+#  define VA_LOCAL_DECL   va_list ap
+#  define VA_START(f)     va_start(ap)      /* f is ignored! */
+#  define VA_SHIFT(v,t) v = va_arg(ap,t)
+#  define VA_END        va_end(ap)
+# else
+/*XX ** NO VARARGS ** XX*/
+# endif
+#endif
+
+#ifdef HAVE_LONG_DOUBLE
+#define LDOUBLE long double
+#else
+#define LDOUBLE double
+#endif
+
+int sprintf (char *str, const char *fmt, ...);
+int snprintf (char *str, size_t count, const char *fmt, ...);
+int vsnprintf (char *str, size_t count, const char *fmt, va_list arg);
+
+static int dopr (char *buffer, size_t maxlen, const char *format, 
+                 va_list args);
+static int fmtstr (char *buffer, size_t *currlen, size_t maxlen,
+		   char *value, int flags, int min, int max);
+static int fmtint (char *buffer, size_t *currlen, size_t maxlen,
+		   long value, int base, int min, int max, int flags);
+static int fmtfp (char *buffer, size_t *currlen, size_t maxlen,
+		  LDOUBLE fvalue, int min, int max, int flags);
+static int dopr_outch (char *buffer, size_t *currlen, size_t maxlen, char c );
+
+/*
+ * dopr(): poor man's version of doprintf
+ */
+
+/* format read states */
+#define DP_S_DEFAULT 0
+#define DP_S_FLAGS   1
+#define DP_S_MIN     2
+#define DP_S_DOT     3
+#define DP_S_MAX     4
+#define DP_S_MOD     5
+#define DP_S_CONV    6
+#define DP_S_DONE    7
+
+/* format flags - Bits */
+#define DP_F_MINUS 	(1 << 0)
+#define DP_F_PLUS  	(1 << 1)
+#define DP_F_SPACE 	(1 << 2)
+#define DP_F_NUM   	(1 << 3)
+#define DP_F_ZERO  	(1 << 4)
+#define DP_F_UP    	(1 << 5)
+#define DP_F_UNSIGNED 	(1 << 6)
+
+/* Conversion Flags */
+#define DP_C_SHORT   1
+#define DP_C_LONG    2
+#define DP_C_LDOUBLE 3
+
+#define char_to_int(p) (p - '0')
+#define MAX(p,q) ((p >= q) ? p : q)
+#define MIN(p,q) ((p <= q) ? p : q)
+
+static int isdigit(int c)
+{
+	return c>='0' && c<='9';
+}
+
+static int dopr (char *buffer, size_t maxlen, const char *format, va_list args)
+{
+  char ch;
+  long value;
+  LDOUBLE fvalue;
+  char *strvalue;
+  int min;
+  int max;
+  int state;
+  int flags;
+  int cflags;
+  int total;
+  size_t currlen;
+  
+  state = DP_S_DEFAULT;
+  currlen = flags = cflags = min = 0;
+  max = -1;
+  ch = *format++;
+  total = 0;
+
+  while (state != DP_S_DONE)
+  {
+    if (ch == '\0')
+      state = DP_S_DONE;
+
+    switch(state) 
+    {
+    case DP_S_DEFAULT:
+      if (ch == '%') 
+	state = DP_S_FLAGS;
+      else 
+	total += dopr_outch (buffer, &currlen, maxlen, ch);
+      ch = *format++;
+      break;
+    case DP_S_FLAGS:
+      switch (ch) 
+      {
+      case '-':
+	flags |= DP_F_MINUS;
+        ch = *format++;
+	break;
+      case '+':
+	flags |= DP_F_PLUS;
+        ch = *format++;
+	break;
+      case ' ':
+	flags |= DP_F_SPACE;
+        ch = *format++;
+	break;
+      case '#':
+	flags |= DP_F_NUM;
+        ch = *format++;
+	break;
+      case '0':
+	flags |= DP_F_ZERO;
+        ch = *format++;
+	break;
+      default:
+	state = DP_S_MIN;
+	break;
+      }
+      break;
+    case DP_S_MIN:
+      if (isdigit(ch)) 
+      {
+	min = 10*min + char_to_int (ch);
+	ch = *format++;
+      } 
+      else if (ch == '*') 
+      {
+	min = va_arg (args, int);
+	ch = *format++;
+	state = DP_S_DOT;
+      } 
+      else 
+	state = DP_S_DOT;
+      break;
+    case DP_S_DOT:
+      if (ch == '.') 
+      {
+	state = DP_S_MAX;
+	ch = *format++;
+      } 
+      else 
+	state = DP_S_MOD;
+      break;
+    case DP_S_MAX:
+      if (isdigit(ch)) 
+      {
+	if (max < 0)
+	  max = 0;
+	max = 10*max + char_to_int (ch);
+	ch = *format++;
+      } 
+      else if (ch == '*') 
+      {
+	max = va_arg (args, int);
+	ch = *format++;
+	state = DP_S_MOD;
+      } 
+      else 
+	state = DP_S_MOD;
+      break;
+    case DP_S_MOD:
+      /* Currently, we don't support Long Long, bummer */
+      switch (ch) 
+      {
+      case 'h':
+	cflags = DP_C_SHORT;
+	ch = *format++;
+	break;
+      case 'l':
+	cflags = DP_C_LONG;
+	ch = *format++;
+	break;
+      case 'L':
+	cflags = DP_C_LDOUBLE;
+	ch = *format++;
+	break;
+      default:
+	break;
+      }
+      state = DP_S_CONV;
+      break;
+    case DP_S_CONV:
+      switch (ch) 
+      {
+      case 'd':
+      case 'i':
+	if (cflags == DP_C_SHORT) 
+	  value = va_arg (args, int);
+	else if (cflags == DP_C_LONG)
+	  value = va_arg (args, long int);
+	else
+	  value = va_arg (args, int);
+	total += fmtint (buffer, &currlen, maxlen, value, 10, min, max, flags);
+	break;
+      case 'o':
+	flags |= DP_F_UNSIGNED;
+	if (cflags == DP_C_SHORT)
+	  value = va_arg (args, unsigned int);
+	else if (cflags == DP_C_LONG)
+	  value = va_arg (args, unsigned long int);
+	else
+	  value = va_arg (args, unsigned int);
+	total += fmtint (buffer, &currlen, maxlen, value, 8, min, max, flags);
+	break;
+      case 'u':
+	flags |= DP_F_UNSIGNED;
+	if (cflags == DP_C_SHORT)
+	  value = va_arg (args, unsigned int);
+	else if (cflags == DP_C_LONG)
+	  value = va_arg (args, unsigned long int);
+	else
+	  value = va_arg (args, unsigned int);
+	total += fmtint (buffer, &currlen, maxlen, value, 10, min, max, flags);
+	break;
+      case 'X':
+	flags |= DP_F_UP;
+      case 'x':
+	flags |= DP_F_UNSIGNED;
+	if (cflags == DP_C_SHORT)
+	  value = va_arg (args, unsigned int);
+	else if (cflags == DP_C_LONG)
+	  value = va_arg (args, unsigned long int);
+	else
+	  value = va_arg (args, unsigned int);
+	total += fmtint (buffer, &currlen, maxlen, value, 16, min, max, flags);
+	break;
+      case 'f':
+	if (cflags == DP_C_LDOUBLE)
+	  fvalue = va_arg (args, LDOUBLE);
+	else
+	  fvalue = va_arg (args, double);
+	/* um, floating point? */
+	total += fmtfp (buffer, &currlen, maxlen, fvalue, min, max, flags);
+	break;
+      case 'E':
+	flags |= DP_F_UP;
+      case 'e':
+	if (cflags == DP_C_LDOUBLE)
+	  fvalue = va_arg (args, LDOUBLE);
+	else
+	  fvalue = va_arg (args, double);
+	break;
+      case 'G':
+	flags |= DP_F_UP;
+      case 'g':
+	if (cflags == DP_C_LDOUBLE)
+	  fvalue = va_arg (args, LDOUBLE);
+	else
+	  fvalue = va_arg (args, double);
+	break;
+      case 'c':
+	total += dopr_outch (buffer, &currlen, maxlen, va_arg (args, int));
+	break;
+      case 's':
+	strvalue = va_arg (args, char *);
+	total += fmtstr (buffer, &currlen, maxlen, strvalue, flags, min, max);
+	break;
+      case 'p':
+	strvalue = va_arg (args, void *);
+	total += fmtint (buffer, &currlen, maxlen, (long) strvalue, 16, min,
+                         max, flags);
+	break;
+      case 'n':
+	if (cflags == DP_C_SHORT) 
+	{
+	  short int *num;
+	  num = va_arg (args, short int *);
+	  *num = currlen;
+        } 
+	else if (cflags == DP_C_LONG) 
+	{
+	  long int *num;
+	  num = va_arg (args, long int *);
+	  *num = currlen;
+        } 
+	else 
+	{
+	  int *num;
+	  num = va_arg (args, int *);
+	  *num = currlen;
+        }
+	break;
+      case '%':
+	total += dopr_outch (buffer, &currlen, maxlen, ch);
+	break;
+      case 'w':
+	/* not supported yet, treat as next char */
+	ch = *format++;
+	break;
+      default:
+	/* Unknown, skip */
+	break;
+      }
+      ch = *format++;
+      state = DP_S_DEFAULT;
+      flags = cflags = min = 0;
+      max = -1;
+      break;
+    case DP_S_DONE:
+      break;
+    default:
+      /* hmm? */
+      break; /* some picky compilers need this */
+    }
+  }
+  if (buffer != NULL)
+  {
+    if (currlen < maxlen - 1) 
+      buffer[currlen] = '\0';
+    else 
+      buffer[maxlen - 1] = '\0';
+  }
+  return total;
+}
+
+static int fmtstr (char *buffer, size_t *currlen, size_t maxlen,
+                   char *value, int flags, int min, int max)
+{
+  int padlen, strln;     /* amount to pad */
+  int cnt = 0;
+  int total = 0;
+  
+  if (value == 0)
+  {
+    value = "<NULL>";
+  }
+
+  for (strln = 0; value[strln]; ++strln); /* strlen */
+  if (max >= 0 && max < strln)
+    strln = max;
+  padlen = min - strln;
+  if (padlen < 0) 
+    padlen = 0;
+  if (flags & DP_F_MINUS) 
+    padlen = -padlen; /* Left Justify */
+
+  while (padlen > 0)
+  {
+    total += dopr_outch (buffer, currlen, maxlen, ' ');
+    --padlen;
+  }
+  while (*value && ((max < 0) || (cnt < max)))
+  {
+    total += dopr_outch (buffer, currlen, maxlen, *value++);
+    ++cnt;
+  }
+  while (padlen < 0)
+  {
+    total += dopr_outch (buffer, currlen, maxlen, ' ');
+    ++padlen;
+  }
+  return total;
+}
+
+/* Have to handle DP_F_NUM (ie 0x and 0 alternates) */
+
+static int fmtint (char *buffer, size_t *currlen, size_t maxlen,
+		   long value, int base, int min, int max, int flags)
+{
+  int signvalue = 0;
+  unsigned long uvalue;
+  char convert[20];
+  int place = 0;
+  int spadlen = 0; /* amount to space pad */
+  int zpadlen = 0; /* amount to zero pad */
+  int caps = 0;
+  int total = 0;
+  
+  if (max < 0)
+    max = 0;
+
+  uvalue = value;
+
+  if(!(flags & DP_F_UNSIGNED))
+  {
+    if( value < 0 ) {
+      signvalue = '-';
+      uvalue = -value;
+    }
+    else
+      if (flags & DP_F_PLUS)  /* Do a sign (+/i) */
+	signvalue = '+';
+    else
+      if (flags & DP_F_SPACE)
+	signvalue = ' ';
+  }
+  
+  if (flags & DP_F_UP) caps = 1; /* Should characters be upper case? */
+
+  do {
+    convert[place++] =
+      (caps? "0123456789ABCDEF":"0123456789abcdef")
+      [uvalue % (unsigned)base  ];
+    uvalue = (uvalue / (unsigned)base );
+  } while(uvalue && (place < 20));
+  if (place == 20) place--;
+  convert[place] = 0;
+
+  zpadlen = max - place;
+  spadlen = min - MAX (max, place) - (signvalue ? 1 : 0);
+  if (zpadlen < 0) zpadlen = 0;
+  if (spadlen < 0) spadlen = 0;
+  if (flags & DP_F_ZERO)
+  {
+    zpadlen = MAX(zpadlen, spadlen);
+    spadlen = 0;
+  }
+  if (flags & DP_F_MINUS) 
+    spadlen = -spadlen; /* Left Justifty */
+
+#ifdef DEBUG_SNPRINTF
+  dprint (1, (debugfile, "zpad: %d, spad: %d, min: %d, max: %d, place: %d\n",
+      zpadlen, spadlen, min, max, place));
+#endif
+
+  /* Spaces */
+  while (spadlen > 0) 
+  {
+    total += dopr_outch (buffer, currlen, maxlen, ' ');
+    --spadlen;
+  }
+
+  /* Sign */
+  if (signvalue) 
+    total += dopr_outch (buffer, currlen, maxlen, signvalue);
+
+  /* Zeros */
+  if (zpadlen > 0) 
+  {
+    while (zpadlen > 0)
+    {
+      total += dopr_outch (buffer, currlen, maxlen, '0');
+      --zpadlen;
+    }
+  }
+
+  /* Digits */
+  while (place > 0) 
+    total += dopr_outch (buffer, currlen, maxlen, convert[--place]);
+  
+  /* Left Justified spaces */
+  while (spadlen < 0) {
+    total += dopr_outch (buffer, currlen, maxlen, ' ');
+    ++spadlen;
+  }
+
+  return total;
+}
+
+static LDOUBLE abs_val (LDOUBLE value)
+{
+  LDOUBLE result = value;
+
+  if (value < 0)
+    result = -value;
+
+  return result;
+}
+
+static LDOUBLE pow10 (int exp)
+{
+  LDOUBLE result = 1;
+
+  while (exp)
+  {
+    result *= 10;
+    exp--;
+  }
+  
+  return result;
+}
+
+static long round (LDOUBLE value)
+{
+  long intpart;
+
+  intpart = value;
+  value = value - intpart;
+  if (value >= 0.5)
+    intpart++;
+
+  return intpart;
+}
+
+static int fmtfp (char *buffer, size_t *currlen, size_t maxlen,
+		  LDOUBLE fvalue, int min, int max, int flags)
+{
+  int signvalue = 0;
+  LDOUBLE ufvalue;
+  char iconvert[20];
+  char fconvert[20];
+  int iplace = 0;
+  int fplace = 0;
+  int padlen = 0; /* amount to pad */
+  int zpadlen = 0; 
+  int caps = 0;
+  int total = 0;
+  long intpart;
+  long fracpart;
+  
+  /* 
+   * AIX manpage says the default is 0, but Solaris says the default
+   * is 6, and sprintf on AIX defaults to 6
+   */
+  if (max < 0)
+    max = 6;
+
+  ufvalue = abs_val (fvalue);
+
+  if (fvalue < 0)
+    signvalue = '-';
+  else
+    if (flags & DP_F_PLUS)  /* Do a sign (+/i) */
+      signvalue = '+';
+    else
+      if (flags & DP_F_SPACE)
+	signvalue = ' ';
+
+#if 0
+  if (flags & DP_F_UP) caps = 1; /* Should characters be upper case? */
+#endif
+
+  intpart = ufvalue;
+
+  /* 
+   * Sorry, we only support 9 digits past the decimal because of our 
+   * conversion method
+   */
+  if (max > 9)
+    max = 9;
+
+  /* We "cheat" by converting the fractional part to integer by
+   * multiplying by a factor of 10
+   */
+  fracpart = round ((pow10 (max)) * (ufvalue - intpart));
+
+  if (fracpart >= pow10 (max))
+  {
+    intpart++;
+    fracpart -= pow10 (max);
+  }
+
+#ifdef DEBUG_SNPRINTF
+  dprint (1, (debugfile, "fmtfp: %f =? %d.%d\n", fvalue, intpart, fracpart));
+#endif
+
+  /* Convert integer part */
+  do {
+    iconvert[iplace++] =
+      (caps? "0123456789ABCDEF":"0123456789abcdef")[intpart % 10];
+    intpart = (intpart / 10);
+  } while(intpart && (iplace < 20));
+  if (iplace == 20) iplace--;
+  iconvert[iplace] = 0;
+
+  /* Convert fractional part */
+  do {
+    fconvert[fplace++] =
+      (caps? "0123456789ABCDEF":"0123456789abcdef")[fracpart % 10];
+    fracpart = (fracpart / 10);
+  } while(fracpart && (fplace < 20));
+  if (fplace == 20) fplace--;
+  fconvert[fplace] = 0;
+
+  /* -1 for decimal point, another -1 if we are printing a sign */
+  padlen = min - iplace - max - 1 - ((signvalue) ? 1 : 0); 
+  zpadlen = max - fplace;
+  if (zpadlen < 0)
+    zpadlen = 0;
+  if (padlen < 0) 
+    padlen = 0;
+  if (flags & DP_F_MINUS) 
+    padlen = -padlen; /* Left Justifty */
+
+  if ((flags & DP_F_ZERO) && (padlen > 0)) 
+  {
+    if (signvalue) 
+    {
+      total += dopr_outch (buffer, currlen, maxlen, signvalue);
+      --padlen;
+      signvalue = 0;
+    }
+    while (padlen > 0)
+    {
+      total += dopr_outch (buffer, currlen, maxlen, '0');
+      --padlen;
+    }
+  }
+  while (padlen > 0)
+  {
+    total += dopr_outch (buffer, currlen, maxlen, ' ');
+    --padlen;
+  }
+  if (signvalue) 
+    total += dopr_outch (buffer, currlen, maxlen, signvalue);
+
+  while (iplace > 0) 
+    total += dopr_outch (buffer, currlen, maxlen, iconvert[--iplace]);
+
+  /*
+   * Decimal point.  This should probably use locale to find the correct
+   * char to print out.
+   */
+  if (max > 0)
+  {
+    total += dopr_outch (buffer, currlen, maxlen, '.');
+
+    while (fplace > 0) 
+      total += dopr_outch (buffer, currlen, maxlen, fconvert[--fplace]);
+  }
+
+  while (zpadlen > 0)
+  {
+    total += dopr_outch (buffer, currlen, maxlen, '0');
+    --zpadlen;
+  }
+
+  while (padlen < 0) 
+  {
+    total += dopr_outch (buffer, currlen, maxlen, ' ');
+    ++padlen;
+  }
+
+  return total;
+}
+
+static int dopr_outch (char *buffer, size_t *currlen, size_t maxlen, char c)
+{
+  if (*currlen + 1 < maxlen)
+    buffer[(*currlen)++] = c;
+  return 1;
+}
+
+#ifndef HAVE_VSNPRINTF
+int vsnprintf (char *str, size_t count, const char *fmt, va_list args)
+{
+  if (str != NULL)
+    str[0] = 0;
+  return dopr(str, count, fmt, args);
+}
+#endif /* !HAVE_VSNPRINTF */
+
+#ifndef HAVE_SNPRINTF
+/* VARARGS3 */
+#ifdef HAVE_STDARGS
+int snprintf (char *str,size_t count,const char *fmt,...)
+#else
+int snprintf (va_alist) va_dcl
+#endif
+{
+#ifndef HAVE_STDARGS
+  char *str;
+  size_t count;
+  char *fmt;
+#endif
+  VA_LOCAL_DECL;
+  int total;
+    
+  VA_START (fmt);
+  VA_SHIFT (str, char *);
+  VA_SHIFT (count, size_t );
+  VA_SHIFT (fmt, char *);
+  total = vsnprintf(str, count, fmt, ap);
+  VA_END;
+  return total;
+}
+#endif /* !HAVE_SNPRINTF */
+
+#ifndef HAVE_SNPRINTF
+/* VARARGS3 */
+#ifdef HAVE_STDARGS
+int sprintf (char *str,const char *fmt,...)
+#else
+int sprintf (va_alist) va_dcl
+#endif
+{
+#ifndef HAVE_STDARGS
+  char *str;
+  char *fmt;
+#endif
+  VA_LOCAL_DECL;
+  int total;
+    
+  VA_START (fmt);
+  VA_SHIFT (str, char *);
+  VA_SHIFT (fmt, char *);
+  total = vsnprintf(str, ~0, fmt, ap);
+  VA_END;
+  return total;
+}
+#endif /* !HAVE_SNPRINTF */
+
+#ifdef TEST_SNPRINTF
+#ifndef LONG_STRING
+#define LONG_STRING 1024
+#endif
+int main (void)
+{
+  char buf1[LONG_STRING];
+  char buf2[LONG_STRING];
+  char *fp_fmt[] = {
+    "%-1.5f",
+    "%1.5f",
+    "%123.9f",
+    "%10.5f",
+    "% 10.5f",
+    "%+22.9f",
+    "%+4.9f",
+    "%01.3f",
+    "%4f",
+    "%3.1f",
+    "%3.2f",
+    "%.0f",
+    "%.1f",
+    NULL
+  };
+  double fp_nums[] = { -1.5, 134.21, 91340.2, 341.1234, 0203.9, 0.96, 0.996, 
+    0.9996, 1.996, 4.136, 0};
+  char *int_fmt[] = {
+    "%-1.5d",
+    "%1.5d",
+    "%123.9d",
+    "%5.5d",
+    "%10.5d",
+    "% 10.5d",
+    "%+22.33d",
+    "%01.3d",
+    "%4d",
+    NULL
+  };
+  long int_nums[] = { -1, 134, 91340, 341, 0203, 0};
+  int x, y;
+  int fail = 0;
+  int num = 0;
+
+  printf ("Testing snprintf format codes against system sprintf...\n");
+
+  for (x = 0; fp_fmt[x] != NULL ; x++)
+    for (y = 0; fp_nums[y] != 0 ; y++)
+    {
+      snprintf (buf1, sizeof (buf1), fp_fmt[x], fp_nums[y]);
+      sprintf (buf2, fp_fmt[x], fp_nums[y]);
+      if (strcmp (buf1, buf2))
+      {
+	printf("snprintf doesn't match Format: %s\n\tsnprintf = %s\n\tsprintf  = %s\n", 
+	    fp_fmt[x], buf1, buf2);
+	fail++;
+      }
+      num++;
+    }
+
+  for (x = 0; int_fmt[x] != NULL ; x++)
+    for (y = 0; int_nums[y] != 0 ; y++)
+    {
+      snprintf (buf1, sizeof (buf1), int_fmt[x], int_nums[y]);
+      sprintf (buf2, int_fmt[x], int_nums[y]);
+      if (strcmp (buf1, buf2))
+      {
+	printf("snprintf doesn't match Format: %s\n\tsnprintf = %s\n\tsprintf  = %s\n", 
+	    int_fmt[x], buf1, buf2);
+	fail++;
+      }
+      num++;
+    }
+  printf ("%d tests failed out of %d.\n", fail, num);
+}
+#endif /* SNPRINTF_TEST */

--- a/libunwind/src/config.h
+++ b/libunwind/src/config.h
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include "UnwindRustSgx.h"
 
 // Define static_assert() unless already defined by compiler.
 #ifndef __has_feature

--- a/libunwind/src/libunwind.cpp
+++ b/libunwind/src/libunwind.cpp
@@ -350,6 +350,11 @@ void _unw_remove_dynamic_fde(unw_word_t fde) {
 
 _LIBUNWIND_HIDDEN
 bool logAPIs() {
+#ifdef RUST_SGX
+  // No get env support for rust binding yet
+  // In sgx we might not want to start logging via an env setting.
+  return true;
+#else
   // do manual lock to avoid use of _cxa_guard_acquire or initializers
   static bool checked = false;
   static bool log = false;
@@ -358,10 +363,16 @@ bool logAPIs() {
     checked = true;
   }
   return log;
+#endif
 }
 
 _LIBUNWIND_HIDDEN
 bool logUnwinding() {
+#ifdef RUST_SGX
+  // No get env support for rust binding yet
+  // In sgx we might not want to start logging via an env setting.
+  return true;
+#else
   // do manual lock to avoid use of _cxa_guard_acquire or initializers
   static bool checked = false;
   static bool log = false;
@@ -370,10 +381,16 @@ bool logUnwinding() {
     checked = true;
   }
   return log;
+#endif
 }
 
 _LIBUNWIND_HIDDEN
 bool logDWARF() {
+#ifdef RUST_SGX
+   // No get env support for rust binding yet
+  // In sgx we might not want to start logging via an env setting.
+  return true;
+#else
   // do manual lock to avoid use of _cxa_guard_acquire or initializers
   static bool checked = false;
   static bool log = false;
@@ -382,6 +399,7 @@ bool logDWARF() {
     checked = true;
   }
   return log;
+#endif
 }
 
 #endif // NDEBUG


### PR DESCRIPTION

1. We support synchronization across multiple threads via functions
exposed by Rust STD lib for this target instead of libunwind.
2. We have implemented dl_iterate_phdr implementation that provides
eh_frm_hdr and text sections for the application running in the enclave.
3. Changes done to support error logging for this target.