### PR TITLE
Enable warnings, enable warnings are erros, fix errors

### DIFF
--- a/libunwind/README_RUST_SGX.md
+++ b/libunwind/README_RUST_SGX.md
@@ -14,7 +14,7 @@ Initial Fork has been made from 5.0 release of llvm (commit: 6a075b6de4)
 * `cd where you want to build libunwind`
 * `mkdir build`
 * `cd build`
-* `cmake -DCMAKE_BUILD_TYPE="RELEASE" -DRUST_SGX=1 -G "Unix Makefiles" -DLLVM_PATH=<path/to/llvm> <path/to/libunwind>`
+* `cmake -DCMAKE_BUILD_TYPE="RELEASE" -DRUST_SGX=1 -G "Unix Makefiles" -DLLVM_ENABLE_WARNINGS=1 -DLIBUNWIND_ENABLE_WERROR=1 -DLIBUNWIND_ENABLE_PEDANTIC=0 -DLLVM_PATH=<path/to/llvm> <path/to/libunwind>`
 * `-DCMAKE_BUILD_TYPE="RELEASE"` could be removed to enable debug logs of libunwind.
 
 ### Build:

--- a/libunwind/src/CMakeLists.txt
+++ b/libunwind/src/CMakeLists.txt
@@ -42,11 +42,13 @@ endif()
 if (RUST_SGX)
     # Compile Flags
     add_definitions(-DRUST_SGX)
-    add_definitions(-DU_FORTIFY_SOURCE)
-    add_definitions(-D_FORTIFY_SOURCE=0)
     add_definitions(-D__NO_STRING_INLINES)
     add_definitions(-D__NO_MATH_INLINES)
     add_definitions(-D_LIBUNWIND_IS_BAREMETAL)
+    # Can't use add_definitions because CMake will reorder these arguments
+    list(APPEND LIBUNWIND_COMPILE_FLAGS -U_FORTIFY_SOURCE)
+    list(APPEND LIBUNWIND_COMPILE_FLAGS -D_FORTIFY_SOURCE=0)
+
     list(APPEND LIBUNWIND_COMPILE_FLAGS -fno-stack-protector)
     list(APPEND LIBUNWIND_COMPILE_FLAGS -ffreestanding)
     list(APPEND LIBUNWIND_COMPILE_FLAGS -fexceptions)

--- a/libunwind/src/UnwindLevel1-gcc-ext.c
+++ b/libunwind/src/UnwindLevel1-gcc-ext.c
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/libunwind/src/UnwindLevel1.c
+++ b/libunwind/src/UnwindLevel1.c
@@ -19,6 +19,9 @@
 // to export these functions from libunwind.so as well.
 #define _LIBUNWIND_UNWIND_LEVEL1_EXTERNAL_LINKAGE 1
 
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#pragma GCC diagnostic ignored "-Wempty-body"
+
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/libunwind/src/UnwindRustSgx.c
+++ b/libunwind/src/UnwindRustSgx.c
@@ -21,7 +21,7 @@
 #define max_log 256
 
 
-__attribute__((weak)) struct _IO_FILE *stderr  = -1;
+__attribute__((weak)) struct _IO_FILE *stderr  = (_IO_FILE *)-1;
 
 static int vwrite_err(const char *format, va_list ap)
 {
@@ -55,7 +55,7 @@ __attribute__((weak)) int fprintf (FILE *__restrict __stream,
         return -1;
     } else {
         va_list args;
-        int ret = 0;
+        ret = 0;
         va_start(args, __format);
         ret += vwrite_err(__format, args);
         va_end(args);
@@ -102,7 +102,7 @@ extern uint64_t TEXT_BASE;
 extern uint64_t TEXT_SIZE;
 extern uint64_t EH_FRM_HDR_BASE;
 extern uint64_t EH_FRM_HDR_SIZE;
-extern void IMAGE_BASE;
+extern char IMAGE_BASE;
 
 typedef Elf64_Phdr Elf_Phdr; 
 int
@@ -121,7 +121,7 @@ dl_iterate_phdr (int (*callback) (struct dl_phdr_info *,
 
     memset(pinfo, 0, sizeof(*pinfo));
 
-    pinfo->dlpi_addr = &IMAGE_BASE;
+    pinfo->dlpi_addr = (ElfW(Addr))&IMAGE_BASE;
     pinfo->dlpi_phnum = 2;
 
     pinfo->dlpi_phdr = phdr;
@@ -154,7 +154,7 @@ void *libuw_malloc(size_t size)
 {
     struct libwu_rs_alloc_meta *meta;
     size_t alloc_size = size + sizeof(struct libwu_rs_alloc_meta);
-    meta = (void *)__rust_alloc(alloc_size, sizeof(size_t));
+    meta = (void *)__rust_c_alloc(alloc_size, sizeof(size_t));
     if (!meta) {
         return NULL;
     }
@@ -169,5 +169,5 @@ void libuw_free(void *p)
         return;
     }
     meta = META_FROM_PTR(p);
-    __rust_dealloc((unsigned char *)meta, meta->alloc_size, sizeof(size_t));
+    __rust_c_dealloc((unsigned char *)meta, meta->alloc_size, sizeof(size_t));
 }

--- a/libunwind/src/UnwindRustSgx.h
+++ b/libunwind/src/UnwindRustSgx.h
@@ -13,6 +13,7 @@
 
 #ifdef RUST_SGX
 
+#undef _GNU_SOURCE
 #define _GNU_SOURCE
 #include <link.h>
 #include <stdarg.h>
@@ -70,22 +71,18 @@ extern "C"  {
 #undef pthread_rwlock_rdlock
 #undef pthread_rwlock_wrlock
 #undef pthread_rwlock_unlock
+#undef PTHREAD_RWLOCK_INITIALIZER
 
 #define pthread_rwlock_t RWLock
-#define PTHREAD_RWLOCK_INITIALIZER RWLOCK_INIT
-
-
 #define pthread_rwlock_rdlock __rust_rwlock_rdlock
 #define pthread_rwlock_wrlock __rust_rwlock_wrlock
 #define pthread_rwlock_unlock __rust_rwlock_unlock
-
+#define PTHREAD_RWLOCK_INITIALIZER RWLOCK_INIT
 
 #define malloc libuw_malloc
 #define free libuw_free
 
-#ifdef dl_iterate_phdr
 #undef dl_iterate_phdr
-#endif
 #define dl_iterate_phdr libuw_dl_iterate_phdr
 
 #ifdef __cplusplus
@@ -95,6 +92,8 @@ extern "C" {
 void *libuw_malloc(size_t size);
 
 void libuw_free(void *p);
+
+struct dl_phdr_info;
 
 int
 libuw_dl_iterate_phdr (int (*callback) (struct dl_phdr_info *,

--- a/libunwind/src/UnwindRustSgxSnprintf.c
+++ b/libunwind/src/UnwindRustSgxSnprintf.c
@@ -5,6 +5,12 @@
  * on all source code distributions
  */
 
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
+#pragma GCC diagnostic ignored "-Wfloat-conversion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wstrict-overflow"
+
 /**************************************************************
  * Original:
  * Patrick Powell Tue Apr 11 09:48:21 PDT 1995

--- a/libunwind/src/libunwind.cpp
+++ b/libunwind/src/libunwind.cpp
@@ -10,6 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#pragma GCC diagnostic ignored "-Wmissing-braces"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic ignored "-Wstrict-overflow"
+
 #include <libunwind.h>
 
 #ifndef NDEBUG


### PR DESCRIPTION
The way we built libunwind, warnings used to be completely ignored. That's very bad. This PR does three things:

* Enable warnings, make all warnings errors
* Use pragmas to ignore existing warnings in upstream sources
* Fix warnings in our code