### PR TITLE
Ignoring implicit-fallthrough check for UnwindRustSgxSnprintf.c

### DIFF
--- a/libunwind/README_RUST_SGX.md
+++ b/libunwind/README_RUST_SGX.md
@@ -15,7 +15,7 @@ Initial Fork has been made from 5.0 release of llvm (commit: 6a075b6de4)
 * `mkdir build`
 * `cd build`
 * `cmake -DCMAKE_BUILD_TYPE="RELEASE" -DRUST_SGX=1 -G "Unix Makefiles" -DLLVM_ENABLE_WARNINGS=1 -DLIBUNWIND_ENABLE_WERROR=1 -DLIBUNWIND_ENABLE_PEDANTIC=0 -DLLVM_PATH=<path/to/llvm> <path/to/libunwind>`
-* `-DCMAKE_BUILD_TYPE="RELEASE"` could be removed to enable debug logs of libunwind.
+* `"DEBUG"` could be used instead of `"RELEASE"` to enable debug logs of libunwind.
 
 ### Build:
 * `make unwind_static`

--- a/libunwind/src/UnwindRustSgxSnprintf.c
+++ b/libunwind/src/UnwindRustSgxSnprintf.c
@@ -10,6 +10,7 @@
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #pragma GCC diagnostic ignored "-Wstrict-overflow"
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 
 /**************************************************************
  * Original:


### PR DESCRIPTION
I tried this commit id in a failed rust-ci docker image, and I could build the libunwind.a there.