### PR TITLE
Specifying assembler used

### DIFF
--- a/libunwind/src/CMakeLists.txt
+++ b/libunwind/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Get sources
 
+enable_language(C CXX ASM)
+
 set(LIBUNWIND_CXX_SOURCES
     libunwind.cpp
     Unwind-EHABI.cpp)
@@ -73,7 +75,7 @@ set_source_files_properties(${LIBUNWIND_C_SOURCES}
                               COMPILE_FLAGS "-std=c99")
 set_source_files_properties(${LIBUNWIND_ASM_SOURCES}
                             PROPERTIES
-                              LANGUAGE C)
+                              LANGUAGE ASM)
 
 set(LIBUNWIND_SOURCES
     ${LIBUNWIND_CXX_SOURCES}


### PR DESCRIPTION
The LVI passes require the use of a hardened assembler for assembly files. Instead of relying on the integrated assembler in clang/clang++, this patch enables developers to specify which assembler to use.